### PR TITLE
Updates for v4

### DIFF
--- a/libs/core/pxt.json
+++ b/libs/core/pxt.json
@@ -125,7 +125,7 @@
                     "device_info_service": 0
                 },
                 "stack_size": 1280,
-                "gatt_table_size": "0x600",
+                "gatt_table_size": "0xD8",
                 "panic_on_heap_full": 0,
                 "debug": 0,
                 "heap_debug": 0,
@@ -139,6 +139,7 @@
                 "config": {
                     "microbit-dal": {
                         "stack_size": 2048,
+                        "gatt_table_size": "0x600",
                         "sram_end": "0x20008000",
                         "RAM_SIZE": "\"32K\""
                     }
@@ -149,6 +150,7 @@
                 "config": {
                     "microbit-dal": {
                         "stack_size": 1280,
+                        "gatt_table_size": "0xD8",
                         "sram_end": "0x20004000",
                         "RAM_SIZE": "\"16K\""
                     }


### PR DESCRIPTION
- decrease default gatt table size to increase stability on 16K devices