### PR TITLE
Remove extensions without MIT License

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -136,8 +136,7 @@
             "tinysuperlab/motionkit",
             "tinysuperlab/touchkit",
             "vengit/pxt-sbrick",
-            "dl1ekm/pxt-calliope-ADS1x15",
-            "dl1ekm/pxt-calliope-PCF85063-RTC"
+            "CalliTGS3/pxt-calliope-grovePCF85063TP"
         ],
         "preferredRepos": [
             "calliope-edu/CO2-Sensor-SCD40",
@@ -171,8 +170,7 @@
             "MKleinSB/pxt-serialmp3",
             "Microsoft/pxt-microturtle",
             "Microsoft/pxt-neopixel",
-            "dl1ekm/pxt-calliope-ADS1x15",
-            "dl1ekm/pxt-calliope-PCF85063-RTC"
+            "CalliTGS3/pxt-calliope-grovePCF85063TP"
         ]
     },
     "galleries": {


### PR DESCRIPTION
> @Amerlander can you please ask the authors of the following repo to add MIT license
> 
> https://github.com/dl1ekm/pxt-calliope-ADS1x15 https://github.com/tinysuperlab/motionkit https://github.com/dl1ekm/pxt-calliope-PCF85063-RTC

@abchatra  https://github.com/tinysuperlab/motionkit already is MIT Licensed. This PR removes the other two.

Replaces `dl1ekm/pxt-calliope-PCF85063-RTC` by `CalliTGS3/pxt-calliope-grovePCF85063TP` 
and removes `dl1ekm/pxt-calliope-ADS1x15`