### PR TITLE
fix case in path

### DIFF
--- a/libs/one-time-pairing/pxt.json
+++ b/libs/one-time-pairing/pxt.json
@@ -10,7 +10,7 @@
     "public": true,
     "searchOnly": true,
     "weight": 100,
-    "icon": "./static/packages/One-Time-Pairing/icon.png",
+    "icon": "./static/packages/one-time-pairing/icon.png",
     "yotta": {
         "config": {
             "microbit-dal": {


### PR DESCRIPTION
This time, there's a snag, the CI was failing because the case of the icon path was wrong.

@abchatra could you merge this fix and bump. I'm sorry for that mistake.