### PR TITLE
update BLE for Codal and one-time-pairing

### DIFF
--- a/libs/one-time-pairing/pxt.json
+++ b/libs/one-time-pairing/pxt.json
@@ -15,9 +15,9 @@
         "config": {
             "microbit-dal": {
                 "bluetooth": {
-                    "open": 1,
-                    "security_level": null,
-                    "whitelist": 0
+                    "open": 0,
+                    "security_level": "SECURITY_MODE_ENCRYPTION_NO_MITM",
+                    "whitelist": 1
                 }
             }
         },


### PR DESCRIPTION
This update changes the behaviour for the one-time-pairing extension.