### PR TITLE
Remove pxt-hacking-stem extension

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -356,7 +356,6 @@
                 ]
             },
             "microsoft/pxt-filesystem": {},
-            "microsoft/pxt-hacking-stem": {},
             "microsoft/pxt-max6675": {},
             "microsoft/pxt-microturtle": {
                 "preferred": true


### PR DESCRIPTION
This extension was renamed microsoft/pxt-data-streamer (already present in target config). Recent changes to the backend caused extension search to fail on redirected repos (fix incoming for that separately).