### PR TITLE
Update SimSidebar flag to new language-based setting

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -625,7 +625,11 @@
         "tours": {
             "editor": "/tours/editor-tour"
         },
-        "tutorialSimSidebarLayout": true,
+        "tutorialSimSidebarLangs": [
+            "blocks",
+            "javascript",
+            "python"
+        ],
         "preferWebUSBDownload": true,
         "hideReplaceMyCode": true,
         "matchWebUSBDeviceInSim": true,


### PR DESCRIPTION
Updating this flag based on the changes in https://github.com/microsoft/pxt/pull/10843.

In calliope, all tutorials use this layout, so all languages are included in the list. There should be no actual change in behavior.