### PR TITLE
configure github actions for npm trusted publishing

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # Required for OIDC
 
 jobs:
   filter-vtags:
@@ -36,7 +37,10 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 18.x
+          node-version: 20.x
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: npm install
         run: |
@@ -67,7 +71,10 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 18.x
+          node-version: 20.x
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: npm install
         run: |
@@ -82,7 +89,7 @@ jobs:
           CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}
           PXT_ACCESS_TOKEN: ${{ secrets.PXT_ACCESS_TOKEN }}
           PXT_RELEASE_REPO: ${{ secrets.PXT_RELEASE_REPO }}
-          NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+          NPM_PUBLISH: true
           CHROME_BIN: chromium-browser
           DISPLAY: :99.0
           CI: true

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "13.0.0",
-        "pxt-core": "12.1.12"
+        "pxt-core": "12.2.8"
     },
     "overrides": {}
 }


### PR DESCRIPTION
also bumping pxt-core to 12.2.8 as that is the version with the required CLI changes.

@Amerlander FYI, I don't think there should be too many problems bumping the minor version