### PR TITLE
Add pxt-calliope-smarthome simx target config

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -649,6 +649,12 @@
                     "sha": "8bab6a87265dc3e1e008a716a478306964b6d889",
                     "devUrl": "https://jacdac.github.io/pxt-jacdac-test/index.html"
                 }
+            },
+            "met-theokoch-schule/pxt-calliope-smarthome": {
+                "simx": {
+                    "sha": "a83b30a25fbd98631ca3ad28de2f3a63add2a67c",
+                    "devUrl": "https://met-theokoch-schule.github.io/pxt-calliope-smarthome/index.html"
+                }
             }
         },
         "approvedEditorExtensionUrls": [


### PR DESCRIPTION
The met-theokoch-schule/pxt-calliope-smarthome extension controls a smart home model built by Theo Koch School in Gruenberg, Germany. It provides blocks for shades, air conditioning, lamps, wall lamp LEDs, touch switches, and presence detection.
Please take a look the readme for a complete guide and pictures.
