### PR TITLE
Update 2026 04

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -226,7 +226,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/calliope-edu/codal-microbit-v2",
-                    "branch": "v0.3.2-calliope-4",
+                    "branch": "v0.3.5-calliope-2",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -226,7 +226,7 @@
                 "codalTarget": {
                     "name": "codal-microbit-v2",
                     "url": "https://github.com/calliope-edu/codal-microbit-v2",
-                    "branch": "v0.3.2-calliope-3",
+                    "branch": "v0.3.2-calliope-4",
                     "type": "git"
                 },
                 "codalBinary": "MICROBIT",

--- a/targetconfig.json
+++ b/targetconfig.json
@@ -71,7 +71,8 @@
                     "AI",
                     "Motor",
                     "IoT"
-                ]
+                ],
+                "preferred": true
             },
             "microsoft/pxt-jacdac": {
                 "tags": [
@@ -103,7 +104,7 @@
                     "devUrl": "http://localhost:3000"
                 }
             },
-            "calliope-edu/display-shield": {
+            "calliope-edu/gamekit": {
                 "tags": [ "Display" ],
                 "simx": {
                     "sha": "055a2804f767879ca3c6f2a86c17451034d86e29",


### PR DESCRIPTION
* Updated the `codal-microbit-v2` to use the ~~`v0.3.2-calliope-4`~~ `v0.3.5-calliope-2` branch.
* renamed the `calliope-edu/display-shield` extension to `calliope-edu/gamekit` 
