### PR TITLE
Add artec-kk/pxt-artecrobo-kit-for-calliope to approvedRepoLib

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -567,6 +567,7 @@
             "kitronikltd/pxt-kitronik-air-quality": {},
             "kitronikltd/pxt-kitronik-air-quality-v2-only": {},
             "artec-kk/pxt-artecrobo-kit": {},
+            "artec-kk/pxt-artecrobo-kit-for-calliope": {},
             "kittenbot/pxt-kittenwifi": { "tags": [ "Networking" ] },
             "sgbotic/pxt-sgbotic-ultimate-sr04-rgb": { "tags": [ "Science" ] },
             "cytrontechnologies/pxt-zoombit": {},


### PR DESCRIPTION
The artec-kk/pxt-artecrobo-kit-for-calliope extension provides blocks to control the Artec Robo Kit accessories from the Calliope mini, including touch sensors, an ultrasonic sensor, a water level sensor, a temperature sensor, an IR photoreflector, a sound sensor, a light sensor, LEDs, a buzzer, DC motors, and servomotors.

This extension is a Calliope mini port of artec-kk/pxt-artecrobo-kit, which is already approved and listed for micro:bit.