### PR TITLE
bump pxt-core and update workflow to use deploy key

### DIFF
--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -93,8 +93,37 @@ jobs:
         env:
           CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}
           PXT_ACCESS_TOKEN: ${{ secrets.PXT_ACCESS_TOKEN }}
-          PXT_RELEASE_REPO: ${{ secrets.PXT_RELEASE_REPO }}
           NPM_PUBLISH: true
           CHROME_BIN: chromium-browser
           DISPLAY: :99.0
           CI: true
+          PXT_SKIP_GIT_COMMIT: true
+
+      - name: Clone release repo
+        uses: actions/checkout@main
+        with:
+          repository: ${{ secrets.BUILT_REPO_NAME }}
+          path: tmp/releases/release
+          fetch-depth: 3
+          fetch-tags: true
+          ssh-key: ${{ secrets.BUILT_REPO_DEPLOY_KEY }}
+
+      - name: Read release info
+        id: release_info
+        run: |
+          tag=$(cat tmp/releases/release.json | jq -r '.tag')
+          url=$(cat tmp/releases/release.json | jq -r '.url')
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Push artifacts to release repo
+        run: |
+          cp -a tmp/releases/built/. tmp/releases/release
+          cd tmp/releases/release
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git add .
+          git commit -m "Release ${{steps.release_info.outputs.tag}} from ${{steps.release_info.outputs.url}}"
+          git tag ${{steps.release_info.outputs.tag}}
+          git push
+          git push --tags

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     },
     "dependencies": {
         "pxt-common-packages": "13.2.8",
-        "pxt-core": "12.3.29"
+        "pxt-core": "13.1.8"
     },
     "overrides": {
         "@blockly/field-grid-dropdown": {


### PR DESCRIPTION
bumping pxt-core to latest and updating the deployment workflow to use deploy key instead of PAT.

i've already created the deploy key and set the secret variables for the action.